### PR TITLE
fix: ignore README files in sphinx build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -70,6 +70,8 @@ exclude_patterns = [
     "jupyter_execute/*",
     ".jupyter_cache",
     "*.venv",
+    "README.md",
+    "**/README.md",
 ]
 
 autodoc_member_order = "groupwise"


### PR DESCRIPTION
The myst-nb library sometimes tries to use README files as part of the build. This generates warnings as the README files are not in any sphinx toctree.

```
/docs/README.md: WARNING: document isn't included in any toctree
```
Telling sphinx to ignore these files ensures we aren't spammed with warnings during the build and can use the `-W` flag to treat warnings as errors.