### PR TITLE
Fix condition for execution mode

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -92,7 +92,7 @@ parent_directory = os.path.dirname(current_directory)
 repo_name = os.path.split(parent_directory)[1]
 
 # Don't execute pytket-cutensornet + pytket-azure examples, execute everything else.
-if repo_name == "pytket-cutensornet" or "pytket-azure":
+if repo_name in ("pytket-cutensornet", "pytket-azure"):
     nb_execution_mode = "off"
 else:
     nb_execution_mode = "cache"


### PR DESCRIPTION
This condition does not work as intended, causing `nb_execution_mode` to always be set to `"off"`. This is causing a bug when trying to build the pytket docs because the docs still contain notebooks but there is no lexer for the code, and the build fails.