### PR TITLE
Nitpicky mode spots broken cross-references

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -105,7 +105,7 @@ coverage_statistics_to_stdout = False
 coverage_show_missing_items = True
 coverage_ignore_classes = []
 coverage_ignore_functions = ["add_wasm", "add_wasm_to_reg", "add_clexpr_from_logicexp"]
-coverage_ignore_modules = ["pytket._tket.libtket", "pytket._tket.libtklog"]
+coverage_ignore_modules = ["libtket", "libtklog"]
 
 # Bit of a hack to avoid executing cutensornet notebooks (needs GPUs)
 # The pytket-azure examples will also not be executable

--- a/conf.py
+++ b/conf.py
@@ -33,11 +33,20 @@ nitpick_ignore = {
     ("py:class", "numpy.ndarray[dtype=complex128, shape=(4, 4), order='F']"),
     ("py:class", "numpy.ndarray[dtype=complex128, shape=(8, 8), order='F']"),
     ("py:class", "numpy.ndarray[dtype=complex128, shape=(*), order='C']"),
-    ("py:class", "scipy.sparse.csc_matrix"),
     ("py:class", "JSON"),
+    # numpy type aliases are documented as data rather than classes, so when 
+    # used in signatures sphinx cannot find the cross-reference as it only 
+    # looks for classes
+    ("py:class", "numpy.typing.ArrayLike"),
+    # similar for our own type aliases
+    ("py:class", "pytket.utils.distribution.T0"),
     # some other packages it is difficult to link to
     ("py:class", "pathlib._local.Path"),
     ("py:class", "jinja2.nodes.Output"),
+}
+
+autodoc_type_aliases = {
+    "npt.ArrayLike": "numpy.typing.ArrayLike",
 }
 
 autosectionlabel_prefix_document = True
@@ -66,9 +75,12 @@ ext_url = pytketdoc_base + "extensions/"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
     "sympy": ("https://docs.sympy.org/latest/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "networkx": ("https://networkx.org/documentation/stable/", None),
+    "graphviz": ("https://graphviz.readthedocs.io/en/stable/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
     "pytket": (pytketdoc_base + "api-docs/", None),
     "pytket-qiskit": (ext_url + "pytket-qiskit/", None),
     "pytket-quantinuum": (

--- a/conf.py
+++ b/conf.py
@@ -101,7 +101,7 @@ intersphinx_mapping = {
 }
 
 coverage_modules = ["pytket"]
-coverage_statistics_to_stdout = False
+coverage_statistics_to_stdout = True
 coverage_show_missing_items = True
 coverage_ignore_classes = []
 coverage_ignore_functions = ["add_wasm", "add_wasm_to_reg", "add_clexpr_from_logicexp"]

--- a/conf.py
+++ b/conf.py
@@ -105,6 +105,7 @@ coverage_statistics_to_stdout = False
 coverage_show_missing_items = True
 coverage_ignore_classes = []
 coverage_ignore_functions = ["add_wasm", "add_wasm_to_reg", "add_clexpr_from_logicexp"]
+coverage_ignore_modules = ["pytket._tket.libtket", "pytket._tket.libtklog"]
 
 # Bit of a hack to avoid executing cutensornet notebooks (needs GPUs)
 # The pytket-azure examples will also not be executable

--- a/conf.py
+++ b/conf.py
@@ -24,8 +24,21 @@ extensions = [
     "sphinxcontrib.googleanalytics",
 ]
 
-# Suppress annoying warnings when building the pytket API docs
-suppress_warnings = ["Inline strong"]
+nitpicky = True
+
+nitpick_ignore = {
+    # nanobind signatures for arrays and JSON do not generate references
+    ("py:class", "numpy.ndarray[dtype=complex128, shape=(*, *), order='F']"),
+    ("py:class", "numpy.ndarray[dtype=complex128, shape=(2, 2), order='F']"),
+    ("py:class", "numpy.ndarray[dtype=complex128, shape=(4, 4), order='F']"),
+    ("py:class", "numpy.ndarray[dtype=complex128, shape=(8, 8), order='F']"),
+    ("py:class", "numpy.ndarray[dtype=complex128, shape=(*), order='C']"),
+    ("py:class", "scipy.sparse.csc_matrix"),
+    ("py:class", "JSON"),
+    # some other packages it is difficult to link to
+    ("py:class", "pathlib._local.Path"),
+    ("py:class", "jinja2.nodes.Output"),
+}
 
 autosectionlabel_prefix_document = True
 
@@ -53,6 +66,7 @@ ext_url = pytketdoc_base + "extensions/"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
     "sympy": ("https://docs.sympy.org/latest/", None),
     "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
     "pytket": (pytketdoc_base + "api-docs/", None),
@@ -71,13 +85,14 @@ intersphinx_mapping = {
     "pytket-qulacs": (ext_url + "pytket-qulacs/", None),
     "pytket-iqm": (ext_url + "pytket-iqm/", None),
     "pytket-stim": (ext_url + "pytket-stim/", None),
+    "pytket-quest": (ext_url + "pytket-quest/", None),
 }
 
 coverage_modules = ["pytket"]
 coverage_statistics_to_stdout = False
 coverage_show_missing_items = True
 coverage_ignore_classes = []
-coverage_ignore_functions = ["add_wasm", "add_wasm_to_reg"]
+coverage_ignore_functions = ["add_wasm", "add_wasm_to_reg", "add_clexpr_from_logicexp"]
 
 # Bit of a hack to avoid executing cutensornet notebooks (needs GPUs)
 # The pytket-azure examples will also not be executable

--- a/conf.py
+++ b/conf.py
@@ -101,7 +101,7 @@ intersphinx_mapping = {
 }
 
 coverage_modules = ["pytket"]
-coverage_statistics_to_stdout = True
+coverage_statistics_to_stdout = False
 coverage_show_missing_items = True
 coverage_ignore_classes = []
 coverage_ignore_functions = ["add_wasm", "add_wasm_to_reg", "add_clexpr_from_logicexp"]


### PR DESCRIPTION
Turning on `nitpicky` raises warnings for any e.g. ``:py:class:`ClassName` `` that fails to link to the docs for `ClassName`, making sure CI can catch this. I have fixed all existing failures in the tket docs (see CQCL/tket#1910 , working towards CQCL/tket#1857 ) but extensions and user manual/examples will need to be checked.