### PR TITLE
Add ignores for python-defined Circuit methods

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -161,8 +161,27 @@ else:
 
 if repo_name == "pytket":
     coverage_modules = ["pytket"]
-    coverage_ignore_functions = ["add_wasm", "add_wasm_to_reg", "add_clexpr_from_logicexp"]
+    coverage_ignore_functions = [
+        "add_wasm",
+        "add_wasm_to_reg",
+        "add_clexpr_from_logicexp",
+        "get_job_shot_num",
+        "get_rng_num",
+        "set_rng_bound",
+        "set_rng_index",
+        "set_rng_seed",
+    ]
     coverage_ignore_modules = ["libtket", "libtklog", "pytket.extensions", "pytket.qir"]
+    coverage_ignore_pyobjects = [
+        "pytket._tket.circuit.Circuit.add_wasm",
+        "pytket._tket.circuit.Circuit.add_wasm_to_reg",
+        "pytket._tket.circuit.Circuit.add_clexpr_from_logicexp",
+        "pytket._tket.circuit.Circuit.get_job_shot_num",
+        "pytket._tket.circuit.Circuit.get_rng_num",
+        "pytket._tket.circuit.Circuit.set_rng_bound",
+        "pytket._tket.circuit.Circuit.set_rng_index",
+        "pytket._tket.circuit.Circuit.set_rng_seed"
+    ]
 elif repo_name == "pytket-qir":
     coverage_modules = ["pytket.qir"]
 else:


### PR DESCRIPTION
In https://github.com/CQCL/tket/blob/main/pytket/pytket/circuit/__init__.py, we extend the C++ Circuit class with python methods. CQCL/tket#1956 added a few more. This PR collects them here rather than having to manually extend the conf.py file when building tket docs. We also ignore the `_tket` versions of them, as we are about to canonicalise the docs links to never have to refer to entries via `_tket`.